### PR TITLE
feat: drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     rev: v3.7.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 flake8 = ">=3.7"
 astor = ">=0.1"
 importlib-metadata = {version = ">=0.9", python = "<3.8"}

--- a/src/flake8_django_migrations/plugin.py
+++ b/src/flake8_django_migrations/plugin.py
@@ -1,16 +1,12 @@
 import ast
+
+# Core Library
+import importlib.metadata as importlib_metadata
 import sys
 from typing import Any, Generator, List, Tuple, Type
 
 from .checkers.issue import Issue
 from .checkers.remove_field import RemoveFieldChecker
-
-if sys.version_info < (3, 8):  # pragma: no cover (<PY38)
-    # Third party
-    import importlib_metadata
-else:  # pragma: no cover (PY38+)
-    # Core Library
-    import importlib.metadata as importlib_metadata
 
 
 class Visitor(ast.NodeVisitor):

--- a/src/flake8_django_migrations/plugin.py
+++ b/src/flake8_django_migrations/plugin.py
@@ -1,5 +1,4 @@
 import ast
-
 import importlib.metadata as importlib_metadata
 from typing import Any, Generator, List, Tuple, Type
 

--- a/src/flake8_django_migrations/plugin.py
+++ b/src/flake8_django_migrations/plugin.py
@@ -1,8 +1,6 @@
 import ast
 
-# Core Library
 import importlib.metadata as importlib_metadata
-import sys
 from typing import Any, Generator, List, Tuple, Type
 
 from .checkers.issue import Issue


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Python 3.7 as it reached EOL on June 27, 2023. More infos: https://devguide.python.org/versions/

Committed via https://github.com/asottile/all-repos